### PR TITLE
OpenSSF Scorecard update for token permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
       - main # trigger deployment when using main branch
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+
+permissions: read-all
+  
 jobs:
   deploy:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Policy is that top level permission must be set in order to narrow - and at most is read-all which has been set.